### PR TITLE
Bootstrap 5.3

### DIFF
--- a/docs/app.vue
+++ b/docs/app.vue
@@ -5,6 +5,7 @@ import ThemeSettingsModal from "~/components/ThemeSettingsModal.vue";
 const themeSettings = ref({
     header: 'classic',
     showSettings: false,
+    dark_theme: false,
     unifiedHeaderSettings: {
         spaced: true,
         app_name: true,

--- a/docs/components/ThemeSettingsModal.vue
+++ b/docs/components/ThemeSettingsModal.vue
@@ -25,6 +25,8 @@ interface Props {
 }
 const props = withDefaults(defineProps<Props>(), {});
 const themeSettings = inject<ThemeSettings>(ThemeSettingsKey);
+
+const runtimeConfig = useRuntimeConfig();
 </script>
 
 <template>
@@ -32,6 +34,23 @@ const themeSettings = inject<ThemeSettings>(ThemeSettingsKey);
         <template #title>
             Theme settings
         </template>
+
+        <!-- Only show dark mode settings if enabled -->
+        <template v-if="runtimeConfig.public.dark_mode">
+            <div class="fw-bold fs-4">
+                Color mode settings
+            </div>
+
+            <div class="form-check form-switch mt-2">
+                <input class="form-check-input" type="checkbox" role="switch" name="spaced" v-model="themeSettings.dark_theme" />
+                <label class="form-check-label" for="spaced">Dark mode</label>
+            </div>
+        </template>
+
+        <div class="fw-bold fs-4 mt-3">
+            Header settings
+        </div>
+
         <label for="header" class="form-label">Header</label>
         <select v-model="themeSettings.header" class="form-select" name="header">
             <option value="classic">

--- a/docs/layouts/default.vue
+++ b/docs/layouts/default.vue
@@ -19,13 +19,16 @@ permissions and limitations under the Licence.
 -->
 <script lang="ts" setup>
 import { ThemeSettings, ThemeSettingsKey } from "~/theme_settings";
+import {computed} from "#imports";
 
 const currentYear = ref(new Date().getFullYear());
 const themeSettings = inject<ThemeSettings>(ThemeSettingsKey);
 
+const colorMode = computed(() => themeSettings?.value.dark_theme ? 'dark' : 'light');
+
 </script>
 <template>
-    <div class="uu-root-container" style="flex-basis: 100%">
+    <div class="uu-root-container" style="flex-basis: 100%" :data-bs-theme="colorMode">
         <ClassicHeader v-if="themeSettings.header === 'classic'" />
         <UnifiedNavbar v-else />
         <slot />

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -8,6 +8,12 @@ export default defineNuxtConfig({
         buildAssetsDir: '/nuxt/'
     },
 
+    runtimeConfig: {
+        public: {
+            dark_mode: false,
+        },
+    },
+
     css: [
         "@/../scss/bootstrap.scss",
     ],

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "@types/bootstrap": "^5.2.0",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",
-    "bootstrap": "5.2.3",
+    "bootstrap": "5.3.0",
     "eslint": "^8.20.0",
     "eslint-plugin-vue": "^9.3.0",
     "nuxt": "^3.0.0",

--- a/docs/theme_settings.ts
+++ b/docs/theme_settings.ts
@@ -3,6 +3,7 @@ import type {InjectionKey, Ref} from 'vue';
 type _ThemeSettings = {
     header: 'unified' | 'classic';
     showSettings: boolean;
+    dark_theme: boolean;
     unifiedHeaderSettings: {
         spaced: boolean;
         app_name: boolean;

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1254,10 +1254,10 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-bootstrap@5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.3.tgz#54739f4414de121b9785c5da3c87b37ff008322b"
-  integrity sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==
+bootstrap@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.0.tgz#0718a7cc29040ee8dbf1bd652b896f3436a87c29"
+  integrity sha512-UnBV3E3v4STVNQdms6jSGO2CvOkjUMdDAVR2V5N4uCMdaIkaQjbcEAMqRimDHIs4uqBYzDAKCQwCB+97tJgHQw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "watch": "yarn _build dist/css/bootstrap.css --watch"
   },
   "dependencies": {
-    "bootstrap": "5.2.1"
+    "bootstrap": "5.3.0"
   },
   "devDependencies": {
     "sass": "^1.53.0"

--- a/scss/components/bootstrap/_alert.scss
+++ b/scss/components/bootstrap/_alert.scss
@@ -1,11 +1,13 @@
 @each $state, $value in $theme-colors {
-  $alert-background: shift-color($value, $alert-bg-scale);
-  $alert-border: shift-color($value, $alert-border-scale);
-  $alert-color: color-contrast($alert-background);
-
-  .alert-#{$state} {
-    @include alert-variant($alert-background, $alert-border, $alert-color);
-  }
+    $alert-background: shift-color($value, $alert-bg-scale);
+    $alert-border: shift-color($value, $alert-border-scale);
+    $alert-color: color-contrast($alert-background);
+    .alert-#{$state} {
+        --#{$prefix}alert-color: #{$alert-color};
+        --#{$prefix}alert-bg: #{$alert-background};
+        --#{$prefix}alert-border-color: #{$alert-border};
+        --#{$prefix}alert-link-color: #{$alert-color};
+    }
 }
 
 .alert {

--- a/scss/components/uu-layout/_navbar.scss
+++ b/scss/components/uu-layout/_navbar.scss
@@ -113,7 +113,8 @@
         }
 
         .show > .nav-link,
-        .nav-link.active {
+        .nav-link.active,
+        .nav-link.show {
             color: var(--#{$prefix}nav-link-hover-color);
         }
     }

--- a/scss/components/uu-layout/_navbar.scss
+++ b/scss/components/uu-layout/_navbar.scss
@@ -76,6 +76,7 @@
         }
 
         .dropdown-menu {
+            --#{$prefix}dropdown-bg: #{$white};
             border-top: none;
 
             &[data-bs-popper] {

--- a/scss/components/uu-layout/_unified_header.scss
+++ b/scss/components/uu-layout/_unified_header.scss
@@ -154,6 +154,7 @@
             }
 
             .dropdown-menu {
+                --#{$prefix}dropdown-bg: #{$white};
                 border-top: none;
 
                 // Spacing fix, todo: figure out why BS places it offset

--- a/scss/configuration/_colors.scss
+++ b/scss/configuration/_colors.scss
@@ -1,3 +1,5 @@
+$enable-dark-mode:            false; // disabled for now TODO actually disable this lol
+
 //// UU Color pallette
 // Primary colors
 $yellow:          #FFCD00;

--- a/scss/configuration/bootstrap/_index.scss
+++ b/scss/configuration/bootstrap/_index.scss
@@ -15,6 +15,7 @@
 
 // 3. Configuration
 @import "node_modules/bootstrap/scss/variables";
+@import "node_modules/bootstrap/scss/variables-dark";
 @import "node_modules/bootstrap/scss/maps";
 @import "node_modules/bootstrap/scss/mixins";
 @import "node_modules/bootstrap/scss/utilities";

--- a/scss/configuration/bootstrap/_modal.scss
+++ b/scss/configuration/bootstrap/_modal.scss
@@ -1,6 +1,7 @@
 @use "../colors";
 
 $modal-content-color: colors.$gray-900;
+$modal-content-bg: colors.$white;
 $modal-content-inner-border-radius: 0;
 $modal-content-border-radius: 0;
 $modal-header-border-width: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bootstrap@5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.1.tgz#45f97ff05cbe828bad807b014d8425f3aeb8ec3a"
-  integrity sha512-UQi3v2NpVPEi1n35dmRRzBJFlgvWHYwyem6yHhuT6afYF+sziEt46McRbT//kVXZ7b1YUYEVGdXEH74Nx3xzGA==
+bootstrap@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.0.tgz#0718a7cc29040ee8dbf1bd652b896f3436a87c29"
+  integrity sha512-UnBV3E3v4STVNQdms6jSGO2CvOkjUMdDAVR2V5N4uCMdaIkaQjbcEAMqRimDHIs4uqBYzDAKCQwCB+97tJgHQw==
 
 braces@~3.0.2:
   version "3.0.2"


### PR DESCRIPTION
This PR updates the bootstrap version used to 5.3. 

An initial set of fixes is also included, but more will probably follow.

Dark mode has been disabled for now, support will be added at a later time. The docs have been updated to test dark mode, but it is disabled by default.